### PR TITLE
匿名認証を実装

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -639,14 +639,28 @@ PODS:
     - firebase_core
     - Flutter
     - nanopb (< 2.30910.0, >= 2.30908.0)
+  - Firebase/Auth (10.12.0):
+    - Firebase/CoreOnly
+    - FirebaseAuth (~> 10.12.0)
   - Firebase/CoreOnly (10.12.0):
     - FirebaseCore (= 10.12.0)
   - Firebase/Firestore (10.12.0):
     - Firebase/CoreOnly
     - FirebaseFirestore (~> 10.12.0)
-  - firebase_core (2.15.0):
+  - firebase_auth (4.9.0):
+    - Firebase/Auth (= 10.12.0)
+    - firebase_core
+    - Flutter
+  - firebase_core (2.15.1):
     - Firebase/CoreOnly (= 10.12.0)
     - Flutter
+  - FirebaseAppCheckInterop (10.14.0)
+  - FirebaseAuth (10.12.0):
+    - FirebaseAppCheckInterop (~> 10.0)
+    - FirebaseCore (~> 10.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.8)
+    - GoogleUtilities/Environment (~> 7.8)
+    - GTMSessionFetcher/Core (< 4.0, >= 2.1)
   - FirebaseCore (10.12.0):
     - FirebaseCoreInternal (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
@@ -667,11 +681,21 @@ PODS:
     - leveldb-library (~> 1.22)
     - nanopb (< 2.30910.0, >= 2.30908.0)
   - Flutter (1.0.0)
+  - GoogleUtilities/AppDelegateSwizzler (7.11.5):
+    - GoogleUtilities/Environment
+    - GoogleUtilities/Logger
+    - GoogleUtilities/Network
   - GoogleUtilities/Environment (7.11.5):
     - PromisesObjC (< 3.0, >= 1.2)
   - GoogleUtilities/Logger (7.11.5):
     - GoogleUtilities/Environment
+  - GoogleUtilities/Network (7.11.5):
+    - GoogleUtilities/Logger
+    - "GoogleUtilities/NSData+zlib"
+    - GoogleUtilities/Reachability
   - "GoogleUtilities/NSData+zlib (7.11.5)"
+  - GoogleUtilities/Reachability (7.11.5):
+    - GoogleUtilities/Logger
   - "gRPC-C++ (1.50.1)":
     - "gRPC-C++/Implementation (= 1.50.1)"
     - "gRPC-C++/Interface (= 1.50.1)"
@@ -733,6 +757,7 @@ PODS:
     - BoringSSL-GRPC (= 0.0.24)
     - gRPC-Core/Interface (= 1.50.1)
   - gRPC-Core/Interface (1.50.1)
+  - GTMSessionFetcher/Core (3.1.1)
   - leveldb-library (1.22.2)
   - nanopb (2.30909.0):
     - nanopb/decode (= 2.30909.0)
@@ -745,6 +770,7 @@ PODS:
 
 DEPENDENCIES:
   - cloud_firestore (from `.symlinks/plugins/cloud_firestore/ios`)
+  - firebase_auth (from `.symlinks/plugins/firebase_auth/ios`)
   - firebase_core (from `.symlinks/plugins/firebase_core/ios`)
   - Flutter (from `Flutter`)
   - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
@@ -754,12 +780,15 @@ SPEC REPOS:
     - abseil
     - BoringSSL-GRPC
     - Firebase
+    - FirebaseAppCheckInterop
+    - FirebaseAuth
     - FirebaseCore
     - FirebaseCoreInternal
     - FirebaseFirestore
     - GoogleUtilities
     - "gRPC-C++"
     - gRPC-Core
+    - GTMSessionFetcher
     - leveldb-library
     - nanopb
     - PromisesObjC
@@ -767,6 +796,8 @@ SPEC REPOS:
 EXTERNAL SOURCES:
   cloud_firestore:
     :path: ".symlinks/plugins/cloud_firestore/ios"
+  firebase_auth:
+    :path: ".symlinks/plugins/firebase_auth/ios"
   firebase_core:
     :path: ".symlinks/plugins/firebase_core/ios"
   Flutter:
@@ -779,7 +810,10 @@ SPEC CHECKSUMS:
   BoringSSL-GRPC: 3175b25143e648463a56daeaaa499c6cb86dad33
   cloud_firestore: 005e157ad342dbfb2e461cb111a9020aa71bfb22
   Firebase: 07150e75d142fb9399f6777fa56a187b17f833a0
-  firebase_core: e477125798fc37cd4ab43ca6a8536bf7e0929c00
+  firebase_auth: 097a2440d40bed75f4dfe4cb91b4d98349509b47
+  firebase_core: 4a3246a02f828a01c74a2c26427037786d90f17f
+  FirebaseAppCheckInterop: c87f1d5421c852413dd936b2b2340b21e62501a0
+  FirebaseAuth: a66c1e14ec58f41d154a4b41ce1a23ea00ad4805
   FirebaseCore: f86a1394906b97ac445ae49c92552a9425831bed
   FirebaseCoreInternal: b342e37cd4f5b4454ec34308f073420e7920858e
   FirebaseFirestore: f94c9541515fa4a49af52269bbc50349009424b4
@@ -787,6 +821,7 @@ SPEC CHECKSUMS:
   GoogleUtilities: 13e2c67ede716b8741c7989e26893d151b2b2084
   "gRPC-C++": 0968bace703459fd3e5dcb0b2bed4c573dbff046
   gRPC-Core: 17108291d84332196d3c8466b48f016fc17d816d
+  GTMSessionFetcher: e8647203b65cee28c5f73d0f473d096653945e72
   leveldb-library: f03246171cce0484482ec291f88b6d563699ee06
   nanopb: b552cce312b6c8484180ef47159bc0f65a1f0431
   PromisesObjC: c50d2056b5253dadbd6c2bea79b0674bd5a52fa4

--- a/lib/firebase/repository/auth/auth_repository.dart
+++ b/lib/firebase/repository/auth/auth_repository.dart
@@ -1,0 +1,28 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// [authRepositoryProvider]は[AuthRepository]のインスタンスを提供するための`Provider`です。
+final authRepositoryProvider = Provider.autoDispose((ref) => AuthRepository());
+
+/// [userIdStateProvider]はユーザーのIDの状態を管理するための`StateProvider`です。
+final userIdStateProvider = StateProvider<String>((ref) => '');
+
+/// [AuthRepository]はFirebase Authenticationとのインタラクションを担当するクラス。
+class AuthRepository {
+  /// FirebaseAuthのインスタンスへの参照。
+  final _auth = FirebaseAuth.instance;
+
+  /// 匿名ユーザーとしてFirebase Authenticationにサインイン。
+  ///
+  /// 成功した場合は[UserCredential]を返し、失敗またはキャンセルされた場合は`null`を返す。
+  Future<UserCredential?> signInAnonymously() async {
+    return _auth.signInAnonymously();
+  }
+
+  /// Firebaseのユーザーの認証状態の変更を購読します。
+  ///
+  /// ユーザーの状態が変更されるたびに[User]をストリームとして送出する。ログアウトまたはサインアウトの場合は`null`を送出する。
+  Stream<User?> subscribeUser() {
+    return _auth.authStateChanges();
+  }
+}

--- a/lib/presentation/view/app.dart
+++ b/lib/presentation/view/app.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:unsubscribe_app/presentation/view/root/root_page.dart';
 
 import '../theme.dart';
 import 'component/loading.dart';
-import 'component/page_viewer.dart';
 
 class App extends ConsumerWidget {
   const App({super.key});
@@ -14,7 +14,7 @@ class App extends ConsumerWidget {
       title: 'サブスク管理',
       debugShowCheckedModeBanner: false,
       theme: ref.read(themeProvider),
-      home: const PageViewer(),
+      home: const RootPage(),
       builder: (context, child) {
         return Consumer(
           builder: (context, ref, _) {

--- a/lib/presentation/view/root/root_page.dart
+++ b/lib/presentation/view/root/root_page.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:unsubscribe_app/presentation/view/component/page_viewer.dart';
+import 'package:unsubscribe_app/presentation/view_model/root/root_page_view_model.dart';
+
+import '../../view_model/root/loading_state.dart';
+import '../component/loading.dart';
+
+class RootPage extends ConsumerWidget {
+  const RootPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final viewModelState = ref.watch(rootPageViewModelProvider);
+    return switch (viewModelState.loginState) {
+      LoginSuccess(user: (final _)) => const PageViewer(),
+      LoginFailure() => const Text('ログインが正常にできませんでした'),
+      LoginLoading() => const OverlayLoading(),
+    };
+  }
+}

--- a/lib/presentation/view/root/root_page.dart
+++ b/lib/presentation/view/root/root_page.dart
@@ -4,7 +4,6 @@ import 'package:unsubscribe_app/presentation/view/component/page_viewer.dart';
 import 'package:unsubscribe_app/presentation/view_model/root/root_page_view_model.dart';
 
 import '../../view_model/root/login_state.dart';
-import '../component/loading.dart';
 
 /// [RootPage]はユーザーのログイン状態に基づいて異なるウィジェットを表示する最も根元にある画面。
 ///
@@ -18,10 +17,13 @@ class RootPage extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final viewModelState = ref.watch(rootPageViewModelProvider);
-    return switch (viewModelState.loginState) {
-      LoginSuccess(user: (final _)) => const PageViewer(),
-      LoginFailure() => const Text('ログインが正常にできませんでした'),
-      LoginLoading() => const OverlayLoading(),
-    };
+    switch (viewModelState.loginState) {
+      case LoginSuccess():
+        return const PageViewer();
+      case LoginFailure(errorText: final errorText):
+        return Text(errorText);
+      case LoginLoading():
+        return const Text('ローディング');
+    }
   }
 }

--- a/lib/presentation/view/root/root_page.dart
+++ b/lib/presentation/view/root/root_page.dart
@@ -3,7 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:unsubscribe_app/presentation/view/component/page_viewer.dart';
 import 'package:unsubscribe_app/presentation/view_model/root/root_page_view_model.dart';
 
-import '../../view_model/root/loading_state.dart';
+import '../../view_model/root/login_state.dart';
 import '../component/loading.dart';
 
 /// [RootPage]はユーザーのログイン状態に基づいて異なるウィジェットを表示する最も根元にある画面。

--- a/lib/presentation/view/root/root_page.dart
+++ b/lib/presentation/view/root/root_page.dart
@@ -6,6 +6,12 @@ import 'package:unsubscribe_app/presentation/view_model/root/root_page_view_mode
 import '../../view_model/root/loading_state.dart';
 import '../component/loading.dart';
 
+/// [RootPage]はユーザーのログイン状態に基づいて異なるウィジェットを表示する最も根元にある画面。
+///
+/// - ログインが成功した場合は、[PageViewer]を表示する。
+/// - ログインに失敗した場合は、エラーメッセージを表示する。
+/// - ログインが進行中の場合は、ローディング画面を表示する。
+///
 class RootPage extends ConsumerWidget {
   const RootPage({super.key});
 

--- a/lib/presentation/view_model/root/loading_state.dart
+++ b/lib/presentation/view_model/root/loading_state.dart
@@ -1,0 +1,12 @@
+import 'package:firebase_auth/firebase_auth.dart';
+
+sealed class LoginState {}
+
+class LoginSuccess extends LoginState {
+  LoginSuccess(this.user);
+  final User user;
+}
+
+class LoginFailure extends LoginState {}
+
+class LoginLoading extends LoginState {}

--- a/lib/presentation/view_model/root/login_state.dart
+++ b/lib/presentation/view_model/root/login_state.dart
@@ -5,10 +5,13 @@ import 'package:firebase_auth/firebase_auth.dart';
 sealed class LoginState {}
 
 class LoginSuccess extends LoginState {
-  LoginSuccess(this.user);
+  LoginSuccess({required this.user});
   final User user;
 }
 
-class LoginFailure extends LoginState {}
+class LoginFailure extends LoginState {
+  LoginFailure({required this.errorText});
+  final String errorText;
+}
 
 class LoginLoading extends LoginState {}

--- a/lib/presentation/view_model/root/login_state.dart
+++ b/lib/presentation/view_model/root/login_state.dart
@@ -1,5 +1,7 @@
 import 'package:firebase_auth/firebase_auth.dart';
 
+/// 参考：https://www.sandromaglione.com/techblog/records-and-patterns-dart-language
+
 sealed class LoginState {}
 
 class LoginSuccess extends LoginState {

--- a/lib/presentation/view_model/root/root_page_view_model.dart
+++ b/lib/presentation/view_model/root/root_page_view_model.dart
@@ -2,7 +2,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:unsubscribe_app/firebase/repository/auth/auth_repository.dart';
 
-import 'loading_state.dart';
+import 'login_state.dart';
 
 /// [RootPageState]は[RootPage]の現在のログイン状態を表現するクラスです。
 ///
@@ -45,7 +45,7 @@ class RootPageViewModel extends StateNotifier<RootPageState> {
         return;
       }
       state = RootPageState(
-        loginState: LoginSuccess(user),
+        loginState: LoginSuccess(user: user),
       );
     });
   }
@@ -56,7 +56,11 @@ class RootPageViewModel extends StateNotifier<RootPageState> {
     try {
       await authRepository.signInAnonymously();
     } on Exception {
-      state = RootPageState(loginState: LoginFailure());
+      state = RootPageState(
+        loginState: LoginFailure(
+          errorText: 'サインインに失敗しました',
+        ),
+      );
     }
   }
 

--- a/lib/presentation/view_model/root/root_page_view_model.dart
+++ b/lib/presentation/view_model/root/root_page_view_model.dart
@@ -4,10 +4,14 @@ import 'package:unsubscribe_app/firebase/repository/auth/auth_repository.dart';
 
 import 'loading_state.dart';
 
+/// [RootPageState]は[RootPage]の現在のログイン状態を表現するクラスです。
+///
+/// [loginState]プロパティによって、ログインが成功、失敗、または読み込み中であるかが示されます。
 class RootPageState {
   RootPageState({required this.loginState});
   final LoginState loginState;
 
+  /// 現在の[RootPageState]のコピーを生成し、指定されたプロパティを使用して更新します。
   RootPageState copyWith({User? user, LoginState? loginState}) {
     return RootPageState(
       loginState: loginState ?? this.loginState,
@@ -15,6 +19,7 @@ class RootPageState {
   }
 }
 
+/// [rootPageViewModelProvider]は[RootPageViewModel]のインスタンスを生成および提供するためのProvider。
 final rootPageViewModelProvider =
     StateNotifierProvider.autoDispose<RootPageViewModel, RootPageState>(
   (ref) => RootPageViewModel(
@@ -22,11 +27,20 @@ final rootPageViewModelProvider =
   ),
 );
 
+/// [RootPageViewModel]は[RootPage]のビジネスロジックを管理するための`StateNotifier`。
+///
+/// このクラスはFirebase Authenticationとのインタラクションを担当し、ログインの成功、失敗、読み込み状態を
+/// [RootPageState]を通じて通知します。
 class RootPageViewModel extends StateNotifier<RootPageState> {
   RootPageViewModel({required this.authRepository})
       : super(RootPageState(loginState: LoginLoading())) {
-    signInAndSubscribeUser();
-    authRepository.subscribeUser().listen((user) {
+    /// 初期化処理はこのスコープで行う
+
+    /// 匿名認証
+    signInAnonymously();
+
+    /// Firebase Authenticationのユーザーの認証状態の変更を購読
+    subscribeUser().listen((user) {
       if (user == null) {
         return;
       }
@@ -37,11 +51,17 @@ class RootPageViewModel extends StateNotifier<RootPageState> {
   }
   final AuthRepository authRepository;
 
-  Future<void> signInAndSubscribeUser() async {
+  /// 匿名でFirebase Authenticationにサインインします。
+  Future<void> signInAnonymously() async {
     try {
       await authRepository.signInAnonymously();
     } on Exception {
       state = RootPageState(loginState: LoginFailure());
     }
+  }
+
+  /// Firebaseのユーザーの認証状態の変更を購読します。
+  Stream<User?> subscribeUser() async* {
+    yield* authRepository.subscribeUser();
   }
 }

--- a/lib/presentation/view_model/root/root_page_view_model.dart
+++ b/lib/presentation/view_model/root/root_page_view_model.dart
@@ -1,0 +1,47 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:unsubscribe_app/firebase/repository/auth/auth_repository.dart';
+
+import 'loading_state.dart';
+
+class RootPageState {
+  RootPageState({required this.loginState});
+  final LoginState loginState;
+
+  RootPageState copyWith({User? user, LoginState? loginState}) {
+    return RootPageState(
+      loginState: loginState ?? this.loginState,
+    );
+  }
+}
+
+final rootPageViewModelProvider =
+    StateNotifierProvider.autoDispose<RootPageViewModel, RootPageState>(
+  (ref) => RootPageViewModel(
+    authRepository: ref.watch(authRepositoryProvider),
+  ),
+);
+
+class RootPageViewModel extends StateNotifier<RootPageState> {
+  RootPageViewModel({required this.authRepository})
+      : super(RootPageState(loginState: LoginLoading())) {
+    signInAndSubscribeUser();
+    authRepository.subscribeUser().listen((user) {
+      if (user == null) {
+        return;
+      }
+      state = RootPageState(
+        loginState: LoginSuccess(user),
+      );
+    });
+  }
+  final AuthRepository authRepository;
+
+  Future<void> signInAndSubscribeUser() async {
+    try {
+      await authRepository.signInAnonymously();
+    } on Exception {
+      state = RootPageState(loginState: LoginFailure());
+    }
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: transitive
     description:
       name: _flutterfire_internals
-      sha256: "5dce45a06d386358334eb1689108db6455d90ceb0d75848d5f4819283d4ee2b8"
+      sha256: "1a5e13736d59235ce0139621b4bbe29bc89839e202409081bc667eb3cd20674c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.4"
+    version: "1.3.5"
   analyzer:
     dependency: transitive
     description:
@@ -233,14 +233,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.4"
+  firebase_auth:
+    dependency: "direct main"
+    description:
+      name: firebase_auth
+      sha256: "6d9be853426ab686d68076b8007ac29b2c31e7d549444a45b5c3fe1abc249fb0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.9.0"
+  firebase_auth_platform_interface:
+    dependency: transitive
+    description:
+      name: firebase_auth_platform_interface
+      sha256: "2946cfdc17f925fa9771dd0ba3ce9dd2d019100a8685d0557c161f7786ea9b14"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.18.0"
+  firebase_auth_web:
+    dependency: transitive
+    description:
+      name: firebase_auth_web
+      sha256: d8972d754702a3f4881184706b8056e2837d0dae91613a43b988c960b8e0d988
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.8.0"
   firebase_core:
     dependency: "direct main"
     description:
       name: firebase_core
-      sha256: "2e9324f719e90200dc7d3c4f5d2abc26052f9f2b995d3b6626c47a0dfe1c8192"
+      sha256: c78132175edda4bc532a71e01a32964e4b4fcf53de7853a422d96dac3725f389
       url: "https://pub.dev"
     source: hosted
-    version: "2.15.0"
+    version: "2.15.1"
   firebase_core_platform_interface:
     dependency: transitive
     description:
@@ -253,10 +277,10 @@ packages:
     dependency: transitive
     description:
       name: firebase_core_web
-      sha256: "0fd5c4b228de29b55fac38aed0d9e42514b3d3bd47675de52bf7f8fccaf922fa"
+      sha256: "4cf4d2161530332ddc3c562f19823fb897ff37a9a774090d28df99f47370e973"
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.0"
+    version: "2.7.0"
   fixnum:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,7 @@ dependencies:
   buy_me_a_coffee_widget: ^2.0.0-nullsafety.0
   cloud_firestore: ^4.8.3
   cupertino_icons: ^1.0.2
+  firebase_auth: ^4.9.0
   firebase_core: ^2.15.0
   flutter:
     sdk: flutter


### PR DESCRIPTION
## 関連する Issue

- #0

## やったこと

- いっちばん根本のRootPageを作成（スクショのイメージ）
- 匿名サインインを実装 
  - `RootPageViewModel`の初期化処理で匿名サインインとユーザー情報の購読をする

doc commentを丁寧に書いたのでコードを読んでもらえるとわかりやすいかも！！！

## やらないこと

- User情報をFirestoreに追加することはしていない

## スクリーンショット

ルート画面の設計

<img width="400" alt="スクリーンショット 2023-09-01 22 19 34" src="https://github.com/tomoki1590/UnsubscribeApp/assets/65523426/61f149bd-dbad-4296-a29a-be8047b3a30e">


## その他

- レビュワーへの参考情報（実装上の懸念点や注意点、追加したパッケージなどあれば記載）
